### PR TITLE
chore: update AGENTS remote-branch guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,5 +13,6 @@ All agents must follow these rules:
 7) Update dependency lockfiles when adding or removing Python dependencies.
 8) If the repo uses mypyc, verify tests run against compiled extensions (not interpreted Python) and note how you confirmed.
 9) Keep base image tags pinned.
+10) If the branch you're assigned to work on is from a remote (ie origin/master or upstream/awesome-feature) you must ensure you fetch and pull from the remote before you begin your work.
 
 Reference: https://www.conventionalcommits.org/en/v1.0.0/


### PR DESCRIPTION
Summary:
- Add guidance in `AGENTS.md` to fetch and update a remote-tracking branch before starting work.

Rationale:
- Ensures changes begin from the latest remote state to avoid stale bases and conflicts.

Details:
- Document the remote-branch update step in `AGENTS.md`.