### PR TITLE
docs: add CI caching and config centralization rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,10 @@ All agents must follow these rules:
 6) Follow formatting/linting configured in pyproject.toml, setup.cfg, tox.ini, or ruff.toml.
 7) Update dependency lockfiles when adding or removing Python dependencies.
 8) If the repo uses mypyc, verify tests run against compiled extensions (not interpreted Python) and note how you confirmed.
-9) Keep base image tags pinned.
-10) If the branch you're assigned to work on is from a remote (ie origin/master or upstream/awesome-feature) you must ensure you fetch and pull from the remote before you begin your work.
+9) Maximize the use of caching in GitHub workflow files to minimize run duration.
+10) Use one of `paths` or `paths-ignore` in every workflow file to make sure workflows only run when required.
+11) All mypy configuration (flags, overrides, per-module ignores, and file targets) should go in pyproject.toml. Do not split config across CLI args, mypy.ini, setup.cfg, or workflow steps.
+12) Centralize pytest settings (flags, markers, ignore patterns, and targets) in pyproject.toml, pytest.ini, setup.cfg, or tox.ini; workflows/hooks should call pytest without inline args.
+13) Keep base image tags pinned.
 
 Reference: https://www.conventionalcommits.org/en/v1.0.0/


### PR DESCRIPTION
## Summary
- Replace the remote-branch fetch/pull rule with CI caching and paths/paths-ignore guidance.
- Document centralized mypy and pytest configuration expectations.

## Rationale
- Improve CI efficiency and keep config guidance consolidated.

## Details
- Update `AGENTS.md` only.
