### PR TITLE
fix(cicd): scope workflow triggers for mypy

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,6 +5,15 @@ on:
   push:
     branches: [main, master, 'release*']
     tags: ['*']
+    paths:
+    - 'docs/**'
+    - 'mypy/errorcodes.py'
+    - 'mypy/main.py'
+    - 'mypyc/doc/**'
+    - '**/*.rst'
+    - '**/*.md'
+    - CREDITS
+    - LICENSE
   pull_request:
     paths:
     - 'docs/**'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,14 @@ on:
   push:
     branches: [main, master, 'release*']
     tags: ['*']
+    paths-ignore:
+    - 'docs/**'
+    - 'mypyc/doc/**'
+    - '**/*.rst'
+    - '**/*.md'
+    - .gitignore
+    - CREDITS
+    - LICENSE
   pull_request:
     paths-ignore:
     - 'docs/**'

--- a/.github/workflows/test_stubgenc.yml
+++ b/.github/workflows/test_stubgenc.yml
@@ -5,6 +5,12 @@ on:
   push:
     branches: [main, master, 'release*']
     tags: ['*']
+    paths:
+    - 'misc/test-stubgenc.sh'
+    - 'mypy/stubgenc.py'
+    - 'mypy/stubdoc.py'
+    - 'mypy/stubutil.py'
+    - 'test-data/pybind11_fixtures/**'
   pull_request:
     paths:
     - 'misc/test-stubgenc.sh'


### PR DESCRIPTION
Summary
- Add path filters for the stubgenc, docs, and test workflows so they run only on relevant changes.

Rationale
- Align workflow triggers with the AGENTS path-filter requirement and reduce unnecessary CI runs.

Details
- Update `.github/workflows/test_stubgenc.yml`, `.github/workflows/docs.yml`, and `.github/workflows/test.yml` to add `paths` / `paths-ignore` for push events.
- Tests: `uv run --python 3.11 --with tox tox -e py311` (failed: dmypy status output mismatch in `mypy/test/testdaemon.py::DaemonSuite::daemon.test::testDaemonStatusKillRestartRecheck`).